### PR TITLE
fix: add Docker volume for Prisma migrations (#43)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - redis
     networks:
       - network
+    volumes:
+      - prisma-migrations:/app/prisma/migrations 
 
   postgres:
     image: postgres:15-alpine
@@ -63,6 +65,7 @@ volumes:
   postgres-data:
   redis-data:
   pgadmin-data:
+  prisma-migrations:
 
 networks:
   network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - network
     volumes:
-      - prisma-migrations:/app/prisma/migrations 
+      - ./prisma/migrations:/app/prisma/migrations
 
   postgres:
     image: postgres:15-alpine


### PR DESCRIPTION
### Summary
Added persistent volume `prisma-migrations` to store Prisma migration files in `/app/prisma/migrations`.  
This ensures Prisma migration history persists across container rebuilds.

### Details
- Mounted `/app/prisma/migrations` to a named volume `prisma-migrations`
- Guarantees migration history is not lost on container rebuilds

### Testing
- Verified that `prisma-migrations` volume is created
- Migration files remain after container restart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved persistence for database migrations to ensure state is retained across container restarts.
  - Enhances reliability of local and containerized environments by keeping migration history consistent.
  - Reduces setup friction and avoids repeated migration re-runs during development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->